### PR TITLE
fix for issue with disabled button receiving focus and disrupting UI

### DIFF
--- a/src/PushButton.vue
+++ b/src/PushButton.vue
@@ -61,7 +61,7 @@ export default Vue.extend({
           name: 'whiteLeft',
           primary: 'border border-gray-300 shadow-sm font-medium rounded-l-md text-gray-700 bg-white',
           dark: 'dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400 hover:dark:bg-gray-500 dark:ring-offset-gray-800',
-          active: 'hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-fuchsia-500 focus:border-fuchsia-500',
+          active: 'hover:bg-gray-50 focus:z-20 focus:outline-none focus:ring-1 focus:ring-fuchsia-500 focus:border-fuchsia-500',
           disabled: '',
         },
         {


### PR DESCRIPTION
This corrects an issue with a disabled leftButton receiving focus (in a button group) and causing the separating border to disappear.  See [Rimsys/rimcentral-be #151](https://app.zenhub.com/workspaces/rimcentral-development-6216a879653af5001140fed2/issues/rimsys/rimcentral2-be/151)